### PR TITLE
Add nearby resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ without having to compile on install time AND will work in both node and electro
 
 Users can override `node-gyp-build` and force compiling by doing `npm install --build-from-source`.
 
+Prebuilds will be attempted loaded from `MODULE_PATH/prebuilds/...` and then next `EXEC_PATH/prebuilds/...` (the latter allowing use with `zeit/pkg`)
+
 ## Supported prebuild names
 
 If so desired you can bundle more specific flavors, for example `musl` builds to support Alpine, or targeting a numbered ARM architecture version.

--- a/index.js
+++ b/index.js
@@ -36,12 +36,11 @@ load.path = function (dir) {
     if (debug) return debug
   }
 
-  // Find most specific flavor first
-  var prebuilds = path.join(dir, 'prebuilds', platform + '-' + arch)
-  var parsed = readdirSync(prebuilds).map(parseTags)
-  var candidates = parsed.filter(matchTags(runtime, abi))
-  var winner = candidates.sort(compareTags(runtime))[0]
-  if (winner) return path.join(prebuilds, winner.file)
+  var prebuild = resolve(dir)
+  if (prebuild) return prebuild
+
+  var nearby = resolve(path.dirname(process.execPath))
+  if (nearby) return nearby
 
   var target = [
     'platform=' + platform,
@@ -54,6 +53,15 @@ load.path = function (dir) {
   ].filter(Boolean).join(' ')
 
   throw new Error('No native build was found for ' + target)
+
+  function resolve (dir) {
+    // Find most specific flavor first
+    var prebuilds = path.join(dir, 'prebuilds', platform + '-' + arch)
+    var parsed = readdirSync(prebuilds).map(parseTags)
+    var candidates = parsed.filter(matchTags(runtime, abi))
+    var winner = candidates.sort(compareTags(runtime))[0]
+    if (winner) return path.join(prebuilds, winner.file)
+  }
 }
 
 function readdirSync (dir) {


### PR DESCRIPTION
This specifically allows loading of native modules with `zeit/pkg`