### PR TITLE
Use env.npm_config_* for electron and upcoming npm

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -57,13 +57,15 @@ function exec (cmd) {
 }
 
 function buildFromSource () {
-  return hasFlag('--build-from-source')
+  return hasFlag('--build-from-source') || process.env.npm_config_build_from_source === 'true'
 }
 
 function verbose () {
-  return hasFlag('--verbose')
+  return hasFlag('--verbose') || process.env.npm_config_loglevel === 'verbose'
 }
 
+// TODO (next major): remove in favor of env.npm_config_* which works since npm
+// 0.1.8 while npm_config_argv will stop working in npm 7. See npm/rfcs#90
 function hasFlag (flag) {
   if (!process.env.npm_config_argv) return false
 


### PR DESCRIPTION
I need this for `electron-builder` and the native addon `ffi-napi`, which recently started using `node-gyp-build` for prebuilds (https://github.com/node-ffi-napi/node-ffi-napi/pull/63) but I want to compile it from source. With [`buildDependenciesFromSource: true`](https://www.electron.build/configuration/configuration) you can instruct `electron-builder` to do so, but this currently does not work with `node-gyp-build`.

The problem is that the `electron-builder` tooling effectively calls `npm rebuild <dep>` and then `npm_config_argv` does not contain `--build-from-source`. However, `env.npm_config_build_from_source` does exist. Hooray!

Incidentally, using `env.npm_config_*` is also the recommended approach by npm and works since npm 0.1.8 while `npm_config_argv` will stop working in npm 7. See npm/rfcs#90.

---

Related: https://github.com/digidem/mapeo-desktop/issues/305