### PR TITLE
Add extra metadata to failed load error

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ load.path = function (dir) {
     armv ? 'armv=' + armv : '',
     'libc=' + libc,
     'node=' + process.versions.node,
-    process.versions.electron ? 'electron=' + process.versions.electron : '',
+    (process.versions && process.versions.electron) ? 'electron=' + process.versions.electron : '',
     typeof __webpack_require__ === 'function' ? 'webpack=true' : '' // eslint-disable-line
   ].filter(Boolean).join(' ')
 

--- a/index.js
+++ b/index.js
@@ -50,10 +50,13 @@ load.path = function (dir) {
     'abi=' + abi,
     'uv=' + uv,
     armv ? 'armv=' + armv : '',
-    'libc=' + libc
+    'libc=' + libc,
+    'node=' + process.versions.node,
+    process.versions.electron ? 'electron=' + process.versions.electron : '',
+    typeof __webpack_require__ === 'function' ? 'webpack=true' : '' // eslint-disable-line
   ].filter(Boolean).join(' ')
 
-  throw new Error('No native build was found for ' + target)
+  throw new Error('No native build was found for ' + target + '\n    loaded from: ' + dir + '\n')
 
   function resolve (dir) {
     // Find most specific flavor first


### PR DESCRIPTION
So the final error thrown here is always what ends up being reported on issue trackers for various native modules.
Maintainers always do the same dance trying to figure out why a prebuild could not be loaded.

I've added some of the metadata here that always ends up being what pinpoints the cause