### PR TITLE
Prefer `npm_config_*` over `os.platform()` and `os.arch()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ var prebuildsOnly = !!process.env.PREBUILDS_ONLY
 var abi = process.versions.modules // TODO: support old node where this is undef
 var runtime = isElectron() ? 'electron' : (isNwjs() ? 'node-webkit' : 'node')
 
-var arch = os.arch()
-var platform = os.platform()
+var arch = process.env.npm_config_arch || os.arch()
+var platform = process.env.npm_config_platform || os.platform()
 var libc = process.env.LIBC || (isAlpine(platform) ? 'musl' : 'glibc')
 var armv = process.env.ARM_VERSION || (arch === 'arm64' ? '8' : vars.arm_version) || ''
 var uv = (process.versions.uv || '').split('.')[0]


### PR DESCRIPTION
I am trying to use https://github.com/ericfreese/node-freetype2 in an electron project. It does not have a darwin-arm64 prebuild yet, meaning it needs to be compiled instead. This is fine when doing the build on an arm64 mac, but when trying to do it on a intel mac, it isnt possible to even force node-gyp-build to make sure the required architecture is available.

This pr uses the standard npm_config_* variables if they exist instead of using that from the current node version. I dont know if listening to `npm_config_platform` makes sense, but it feels appropriate to use for consistency