### PR TITLE
Support cross-installing of prebuilt packages via npm_config_* vars

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -4,13 +4,22 @@ var proc = require('child_process')
 var os = require('os')
 var path = require('path')
 
+var targetMismatch = (process.env.npm_config_platform && process.platform !== process.env.npm_config_platform) ||
+  (process.env.npm_config_arch && process.arch !== process.env.npm_config_arch)
+
 if (!buildFromSource()) {
-  proc.exec('node-gyp-build-test', function (err, stdout, stderr) {
-    if (err) {
-      if (verbose()) console.error(stderr)
-      preinstall()
-    }
-  })
+  if (targetMismatch) {
+    // If the target is mismatched, then we can't test built output, and we can't build from source either.
+    // Instead, we just check whether a matching prebuild exists, and fail if it doesn't.
+    require('./index').path(process.cwd())
+  } else {
+    proc.exec('node-gyp-build-test', function (err, stdout, stderr) {
+      if (err) {
+        if (verbose()) console.error(stderr)
+        preinstall()
+      }
+    })
+  }
 } else {
   preinstall()
 }


### PR DESCRIPTION
See https://github.com/vweevers/win-version-info/issues/29 for context.

With this change, if `npm_config_platform` or `npm_config_arch` are set, and either one doesn't match the current machine, then the build isn't tested (since the test result will be wrong) and instead we just check if there's a matching prebuild available. If not, the install fails completely (because we can't easily cross-compile for targets like this).

I've tested this in [win-version-info](https://github.com/vweevers/win-version-info) with its win32-only prebuilds, disabling the `skip.js` test there, on Linux.

Cross-installing for win32:

```bash
$ npm_config_platform=win32 npm install

> win-version-info@6.0.1 install
> node-gyp-build


up to date, audited 774 packages in 2s

218 packages are looking for funding
  run `npm fund` for details
```

=> Correctly notices there's a valid win32 prebuild available, doesn't build anything, all good.

Cross-installing for a target with no prebuilds available:

```bash
$ npm_config_platform=win98 npm install

> win-version-info@6.0.1 install
> node-gyp-build

.../node-gyp-build/index.js:60
  throw new Error('No native build was found for ' + target + '\n    loaded from: ' + dir + '\n')
  ^

Error: No native build was found for platform=win98 arch=x64 runtime=node abi=93 uv=1 libc=glibc node=16.16.0
    loaded from: .../win-version-info

    at Function.load.path (.../node-gyp-build/index.js:60:9)
    at Object.<anonymous> (.../node-gyp-build/bin.js:14:24)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
npm ERR! code 1
npm ERR! path .../win-version-info
npm ERR! command failed
npm ERR! command sh -c node-gyp-build

npm ERR! A complete log of this run can be found in:
npm ERR!     .../.npm/_logs/2022-08-05T12_04_03_956Z-debug-0.log
```

=> Can't find a prebuild for the target platform, fails explicitly instead of building for the real platform incorrectly.