### PR TITLE
Fix local node-gyp path

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -21,7 +21,7 @@ function build () {
   try {
     args = [
       process.execPath,
-      path.join(require.resolve('node-gyp/package.json'), '..', require('node-gyp/package.json').bin['node-gyp']),
+      path.join(require.resolve('node-gyp/package.json'), '..', require('node-gyp/package.json').bin),
       'rebuild'
     ]
   } catch (_) {}


### PR DESCRIPTION
Hi!

As can be seen [here](https://github.com/nodejs/node-gyp/blob/main/package.json#L22), `node-gyp` is specifying the `bin` field in their `package.json` as a string, instead of as a map (which [seems to be valid](https://docs.npmjs.com/cli/v9/configuring-npm/package-json?v=true#bin) when a package has a single executable and its name should be the same as that of the package).

This PR changes the local node-gyp path detection logic to take this into account.