### PR TITLE
README: Add doc for preinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Users can override `node-gyp-build` and force compiling by doing `npm install --
 
 Prebuilds will be attempted loaded from `MODULE_PATH/prebuilds/...` and then next `EXEC_PATH/prebuilds/...` (the latter allowing use with `zeit/pkg`)
 
+You can pass a command to execute before building from sources, for instance, to clone a repository.
+
+``` sh
+node-gyp-build ./clone-repo.js
+```
+
 ## Supported prebuild names
 
 If so desired you can bundle more specific flavors, for example `musl` builds to support Alpine, or targeting a numbered ARM architecture version.


### PR DESCRIPTION
Reading `bin.js`, when building from source, I discovered a `preinstall` function executes `process.argv[2]` if it exists.

Passing a command to run only when rebuilding from source is great to fetch sources needed only when rebuilding for instance.

I suggest adding documentation to the README.md about this feature.