### PR TITLE
Test: Add Node.js v22 and update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [8, 16, 18, 20]
+        node: [8, 16, 18, 20, latest]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Node ${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Install


### PR DESCRIPTION
* https://github.com/actions/setup-node#supported-version-syntax -- Currently `latest` is `v21.7.1`.
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-node/releases