### PR TITLE
Add dedicated export for Bare

### DIFF
--- a/bare.js
+++ b/bare.js
@@ -1,0 +1,1 @@
+module.exports = require.addon.bind(require)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "4.8.2",
   "description": "Build tool and bindings loader for node-gyp that supports prebuilds",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "bare": "./bare.js",
+      "default": "./index.js"
+    },
+    "./package": "./package.json"
+  },
   "devDependencies": {
     "array-shuffle": "^1.0.1",
     "standard": "^14.0.0",


### PR DESCRIPTION
No imports mappings are defined for the Node.js builtins used in `node-gyp-build.js`, tripping up https://github.com/holepunchto/bare-pack when bundling for Bare. Bare doesn't need any of that though and a dedicated export that just forwards to `require.addon()` is sufficient.